### PR TITLE
Replace Poetry and Hatch with uv in contributing guide, readme and justfile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Request features on the [Issue Tracker].
 
 ## How to set up your development environment
 
-You need Python 3.8+ and the following tools:
+You need Python 3.10+ and the following tools:
 
 - [uv]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,21 +39,21 @@ Request features on the [Issue Tracker].
 
 You need Python 3.8+ and the following tools:
 
-- [Poetry]
+- [uv]
 
 Install the package with development requirements:
 
 ```console
-$ poetry install
+$ uv sync
 ```
-[poetry]: https://python-poetry.org/
+[uv]: https://github.com/astral-sh/uv
 
 ## How to test the project
 
 Run the full test suite:
 
 ```console
-$ pytest
+$ uv run pytest
 ```
 
 Unit tests are located in the _tests_ directory,
@@ -76,7 +76,7 @@ Feel free to submit early, though—we can always iterate on this.
 To run linting and code formatting checks before committing your change, you can install pre-commit as a Git hook by running the following command:
 
 ```console
-$ pre-commit -- install
+$ uv run pre-commit -- install
 ```
 
 It is recommended to open an issue before starting work on anything.

--- a/README.md
+++ b/README.md
@@ -109,18 +109,17 @@ This project is used by the following companies:
 
 ## Development
 
-Poetry is required (not really, you can set up the environment however you want and install the requirements
-manually) to set up a virtualenv, install it then run the following:
+uv is required to set up a virtualenv, install it then run the following:
 
 ```sh
-poetry install
-pre-commit install --install-hooks
+uv sync
+uv run pre-commit install --install-hooks
 ```
 
 Tests can then be run quickly in that environment:
 
 ```sh
-pytest
+uv run pytest
 ```
 
 ## Feedback

--- a/justfile
+++ b/justfile
@@ -4,21 +4,16 @@ _default:
 
 # Install dependencies
 @bootstrap:
-    hatch env create
-    hatch env create docs
+    uv sync
 
 # Run tests using pytest
 @test *ARGS:
-    hatch run pytest {{ ARGS }}
+    uv run --group dev pytest {{ ARGS }}
 
 # Build documentation using Sphinx
 @docs-build LOCATION="docs/_build/html":
-    sphinx-build docs {{ LOCATION }}
-
-# Install documentation dependencies
-@docs-install:
-    hatch run docs:python --version
+	uv run --group docs sphinx-build docs {{ LOCATION }}
 
 # Serve documentation locally
 @docs-serve:
-    hatch run docs:sphinx-autobuild docs docs/_build/html --port 8001
+	uv run --group docs sphinx-autobuild docs docs/_build/html --port 8001


### PR DESCRIPTION
Update contributing guide removing Poetry usage instructions and replacing them with uv instead, reflecting the current state of `pyproject.toml`, as well as changing the Python 3.8+ requirement description to 3.10+. Similar changes applied to main README.md file.

Fixed non-working justfile by changing hatch commands to uv equivalents, all just commands should work as expected now.